### PR TITLE
Refactor: Use dependency files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: actions/checkout@master
       - uses: denolib/setup-deno@master
         with:
-          deno-version: x
+          deno-version: v1.2.0
       - run: deno test -A

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: actions/checkout@master
       - uses: denolib/setup-deno@master
         with:
-          deno-version: v1.2.0
+          deno-version: v1.2.2
       - run: deno test -A

--- a/README.md
+++ b/README.md
@@ -96,11 +96,12 @@ The server will respond to a **GET** request with a newly created JWT.
 On the other hand, if you send a JWT as data along with a **POST** request, the
 server will check the validity of the JWT.
 
+Always use [versioned imports](https://deno.land/x) for your dependencies.
+
 ```typescript
-//Always use versioned imports for your dependencies
-import { serve } from "https://deno.land/std/http/server.ts"
-import { validateJwt } from "https://deno.land/x/djwt/validate.ts"
-import { makeJwt, setExpiration, Jose, Payload } from "https://deno.land/x/djwt/create.ts"
+import { serve } from "https://deno.land/std/http/server.ts";
+import { validateJwt } from "https://deno.land/x/djwt/validate.ts";
+import { makeJwt, setExpiration, Jose, Payload } from "https://deno.land/x/djwt/create.ts";
 
 const key = "your-secret";
 const payload: Payload = {
@@ -133,4 +134,5 @@ implementation for the [Oak](https://oakserver.github.io/oak/) framework
 
 ## Contribution
 
-Every kind of contribution to this project is highly appreciated.
+Every kind of contribution to this project is highly appreciated.  
+Please run `deno fmt` on the changed files before making a pull request.

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ The server will respond to a **GET** request with a newly created JWT.
 On the other hand, if you send a JWT as data along with a **POST** request, the
 server will check the validity of the JWT.
 
-```javascript
-import { serve } from "https://deno.land/std@v0.61.0/http/server.ts"
+```typescript
+//Always use versioned imports for your dependencies
+import { serve } from "https://deno.land/std/http/server.ts"
 import { validateJwt } from "https://deno.land/x/djwt/validate.ts"
 import { makeJwt, setExpiration, Jose, Payload } from "https://deno.land/x/djwt/create.ts"
 

--- a/base64/base64url.ts
+++ b/base64/base64url.ts
@@ -4,7 +4,7 @@ import {
 } from "./base64.ts";
 import {
   addPaddingToBase64url,
-} from "https://deno.land/std@v0.61.0/encoding/base64url.ts";
+} from "../deps.ts";
 
 function convertBase64urlToBase64(base64url: string): string {
   return addPaddingToBase64url(base64url).replace(/\-/g, "+").replace(

--- a/create.ts
+++ b/create.ts
@@ -1,7 +1,9 @@
 import { convertUint8ArrayToBase64url } from "./base64/base64url.ts";
-import { decodeString as convertHexToUint8Array } from "https://deno.land/std@v0.61.0/encoding/hex.ts";
-import { HmacSha256 } from "https://deno.land/std@v0.61.0/hash/sha256.ts";
-import { HmacSha512 } from "https://deno.land/std@v0.61.0/hash/sha512.ts";
+import {
+  convertHexToUint8Array,
+  HmacSha256,
+  HmacSha512,
+} from "./deps.ts";
 
 type Algorithm = "none" | "HS256" | "HS512";
 type JsonPrimitive = string | number | boolean | null;
@@ -36,7 +38,7 @@ interface Jose {
 // returns the number of seconds since January 1, 1970, 00:00:00 UTC
 function setExpiration(exp: number | Date): number {
   return Math.round(
-    (exp instanceof Date ? exp.getTime() : Date.now() + exp * 1000) / 1000
+    (exp instanceof Date ? exp.getTime() : Date.now() + exp * 1000) / 1000,
   );
 }
 
@@ -49,9 +51,11 @@ function convertStringToBase64url(input: string): string {
 }
 
 function makeSigningInput(header: Jose, payload?: Payload): string {
-  return `${convertStringToBase64url(
-    JSON.stringify(header)
-  )}.${convertStringToBase64url(JSON.stringify(payload || ""))}`;
+  return `${
+    convertStringToBase64url(
+      JSON.stringify(header),
+    )
+  }.${convertStringToBase64url(JSON.stringify(payload || ""))}`;
 }
 
 function encrypt(alg: Algorithm, key: string, msg: string): string | null {

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,4 @@
+export { decodeString as convertHexToUint8Array } from "https://deno.land/std@v0.61.0/encoding/hex.ts";
+export { HmacSha256 } from "https://deno.land/std@v0.61.0/hash/sha256.ts";
+export { HmacSha512 } from "https://deno.land/std@v0.61.0/hash/sha512.ts";
+export { addPaddingToBase64url } from "https://deno.land/std@v0.61.0/encoding/base64url.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { decodeString as convertHexToUint8Array } from "https://deno.land/std@v0.61.0/encoding/hex.ts";
-export { HmacSha256 } from "https://deno.land/std@v0.61.0/hash/sha256.ts";
-export { HmacSha512 } from "https://deno.land/std@v0.61.0/hash/sha512.ts";
-export { addPaddingToBase64url } from "https://deno.land/std@v0.61.0/encoding/base64url.ts";
+export { decodeString as convertHexToUint8Array } from "https://deno.land/std@v0.63.0/encoding/hex.ts";
+export { HmacSha256 } from "https://deno.land/std@v0.63.0/hash/sha256.ts";
+export { HmacSha512 } from "https://deno.land/std@v0.63.0/hash/sha512.ts";
+export { addPaddingToBase64url } from "https://deno.land/std@v0.63.0/encoding/base64url.ts";

--- a/examples/example_deps.ts
+++ b/examples/example_deps.ts
@@ -1,0 +1,2 @@
+export { serve } from "https://deno.land/std@v0.61.0/http/server.ts";
+export { encode, decode } from "https://deno.land/std@v0.61.0/encoding/utf8.ts";

--- a/examples/example_deps.ts
+++ b/examples/example_deps.ts
@@ -1,2 +1,2 @@
-export { serve } from "https://deno.land/std@v0.61.0/http/server.ts";
-export { encode, decode } from "https://deno.land/std@v0.61.0/encoding/utf8.ts";
+export { serve } from "https://deno.land/std@v0.63.0/http/server.ts";
+export { encode, decode } from "https://deno.land/std@v0.63.0/encoding/utf8.ts";

--- a/examples/mini_example.ts
+++ b/examples/mini_example.ts
@@ -1,5 +1,5 @@
-import { serve } from "https://deno.land/std@v0.61.0/http/server.ts";
-import { encode, decode } from "https://deno.land/std@v0.61.0/encoding/utf8.ts";
+import { serve } from "./example_deps.ts";
+import { encode, decode } from "./example_deps.ts";
 import { makeJwt } from "../create.ts";
 import { validateJwt } from "../validate.ts";
 
@@ -17,12 +17,12 @@ for await (const req of serve("0.0.0.0:8000")) {
     });
   } else {
     (
-      await validateJwt({
-        jwt: decode(await Deno.readAll(req.body)),
-        key: "abc123",
-        algorithm: "HS256",
-      })
-    ).isValid
+        await validateJwt({
+          jwt: decode(await Deno.readAll(req.body)),
+          key: "abc123",
+          algorithm: "HS256",
+        })
+      ).isValid
       ? req.respond({ body: encode("Valid JWT\n") })
       : req.respond({ status: 401, body: encode("Invalid JWT\n") });
   }

--- a/examples/readme_example.ts
+++ b/examples/readme_example.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@v0.61.0/http/server.ts";
+import { serve } from "./example_deps.ts";
 import { validateJwt } from "../validate.ts";
 import { makeJwt, setExpiration, Jose, Payload } from "../create.ts";
 

--- a/tests/base64_test.ts
+++ b/tests/base64_test.ts
@@ -1,10 +1,10 @@
-import { assertEquals } from "https://deno.land/std@v0.61.0/testing/asserts.ts";
+import { assertEquals } from "./test_deps.ts";
 import {
   convertBase64ToUint8Array,
   convertUint8ArrayToBase64,
   convertStringToBase64,
   convertBase64ToString,
-} from "../base64.ts";
+} from "../base64/base64.ts";
 
 const str1 = "Hello ☸☹☺☻☼☾☿ World ✓";
 const str2 = "Man Ё𤭢";
@@ -16,13 +16,26 @@ Deno.test("convertBase64ToUint8ArrayAndBackTest", function (): void {
     uint8Array1,
     convertBase64ToUint8Array(convertUint8ArrayToBase64(uint8Array1)),
   );
+  assertEquals(
+    uint8Array2,
+    convertBase64ToUint8Array(convertUint8ArrayToBase64(uint8Array2)),
+  );
 });
 
 Deno.test("convertBase64ToStringAndBackTest", function (): void {
   assertEquals(str1, convertBase64ToString(convertStringToBase64(str1)));
+  assertEquals(str2, convertBase64ToString(convertStringToBase64(str2)));
 });
 
 Deno.test("convertMultiByteCharactersTest", function (): void {
+  assertEquals(
+    convertBase64ToString(
+      convertUint8ArrayToBase64(
+        convertBase64ToUint8Array(convertStringToBase64(str1)),
+      ),
+    ),
+    str1,
+  );
   assertEquals(
     convertBase64ToString(
       convertUint8ArrayToBase64(

--- a/tests/base64url_test.ts
+++ b/tests/base64url_test.ts
@@ -1,9 +1,9 @@
-import { assertEquals } from "https://deno.land/std@v0.61.0/testing/asserts.ts";
+import { assertEquals } from "./test_deps.ts";
 import {
   convertBase64ToBase64url,
   convertBase64urlToBase64,
-} from "../base64url.ts";
-import { convertUint8ArrayToBase64 } from "../base64.ts";
+} from "../base64/base64url.ts";
+import { convertUint8ArrayToBase64 } from "../base64/base64.ts";
 
 const oneBase64 = "c3ViamVjdHM/X2Q9MQ==";
 const oneBase64url = "c3ViamVjdHM_X2Q9MQ";

--- a/tests/djwt_test.ts
+++ b/tests/djwt_test.ts
@@ -21,13 +21,11 @@ import {
   convertUint8ArrayToBase64,
 } from "../base64/base64.ts";
 import {
-  encodeToString as convertUint8ArrayToHex,
-  decodeString as convertHexToUint8Array,
-} from "https://deno.land/std@v0.61.0/encoding/hex.ts";
-import {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@v0.61.0/testing/asserts.ts";
+  convertUint8ArrayToHex,
+  convertHexToUint8Array,
+} from "./test_deps.ts";
 
 const key = "your-secret";
 
@@ -65,14 +63,14 @@ Deno.test("makeDataConversionTest", function (): void {
             convertHexToUint8Array(
               convertUint8ArrayToHex(
                 convertBase64ToUint8Array(
-                  convertBase64urlToBase64(convertHexToBase64url(hex1))
-                )
-              )
-            )
-          )
-        )
-      )
-    )
+                  convertBase64urlToBase64(convertHexToBase64url(hex1)),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
   );
   assertEquals(hex1, hex2);
 });
@@ -85,15 +83,15 @@ Deno.test("makeSignatureTests", async function (): Promise<void> {
     "p2KneqJhji8T0PDlVxcG4DROyzTgWXbDhz_mcTVojXo";
   assertEquals(
     makeSignature("HS256", "m$y-key", "thisTextWillBeEncrypted"),
-    convertHexToBase64url(computedHmacInHex)
+    convertHexToBase64url(computedHmacInHex),
   );
   assertEquals(
     makeSignature(
       "HS256",
       "m$y-key",
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ",
     ),
-    anotherVerifiedSignatureInBase64Url
+    anotherVerifiedSignatureInBase64Url,
   );
 });
 
@@ -126,7 +124,7 @@ Deno.test("makeValidateJwtObjectTest", async function (): Promise<void> {
       });
     },
     ReferenceError,
-    "header parameter 'alg' is not a string"
+    "header parameter 'alg' is not a string",
   );
 });
 
@@ -163,7 +161,7 @@ Deno.test("parseAndDecodeTests", async function (): Promise<void> {
   });
   assertEquals(
     await makeJwt({ header, payload, key: "your-256-bit-secret" }),
-    jwt
+    jwt,
   );
 });
 
@@ -181,14 +179,14 @@ Deno.test("makeCreationAndValidationTest", async function (): Promise<void> {
   const validatedJwt = await validateJwt({ jwt, key, algorithm: "HS256" });
   assertEquals(
     jwt,
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SARsBE5x_ua2ye823r2zKpQNaew3Daq8riKz5A4h3o4"
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SARsBE5x_ua2ye823r2zKpQNaew3Daq8riKz5A4h3o4",
   );
   if (validatedJwt.isValid) {
     assertEquals(validatedJwt!.payload, payload);
     assertEquals(validatedJwt!.header, header);
     assertEquals(
       jwt.slice(jwt.lastIndexOf(".") + 1),
-      convertHexToBase64url(validatedJwt!.signature)
+      convertHexToBase64url(validatedJwt!.signature),
     );
   } else {
     throw new Error("invalid JWT");
@@ -280,7 +278,7 @@ Deno.test("makeHeaderCritTest", async function (): Promise<void> {
     assertEquals(validatedJwt!.header, header);
     assertEquals(
       jwt.slice(jwt.lastIndexOf(".") + 1),
-      convertHexToBase64url(validatedJwt!.signature)
+      convertHexToBase64url(validatedJwt!.signature),
     );
   } else {
     throw new Error("invalid JWT");
@@ -291,7 +289,7 @@ Deno.test("makeHeaderCritTest", async function (): Promise<void> {
   else {
     assertEquals(
       failing.error.message,
-      "critical extension header parameters are not understood"
+      "critical extension header parameters are not understood",
     );
     assertEquals(failing.isExpired, false);
   }

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -1,8 +1,8 @@
 export {
   encodeToString as convertUint8ArrayToHex,
   decodeString as convertHexToUint8Array,
-} from "https://deno.land/std@v0.61.0/encoding/hex.ts";
+} from "https://deno.land/std@v0.63.0/encoding/hex.ts";
 export {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@v0.61.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.63.0/testing/asserts.ts";

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -1,0 +1,8 @@
+export {
+  encodeToString as convertUint8ArrayToHex,
+  decodeString as convertHexToUint8Array,
+} from "https://deno.land/std@v0.61.0/encoding/hex.ts";
+export {
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@v0.61.0/testing/asserts.ts";

--- a/validate.ts
+++ b/validate.ts
@@ -35,7 +35,7 @@ function isObject(obj: unknown): obj is object {
 
 function has<K extends string>(
   key: K,
-  x: object
+  x: object,
 ): x is { [key in K]: unknown } {
   return key in x;
 }
@@ -48,17 +48,39 @@ function isExpired(exp: number, leeway = 0): boolean {
 // must understand and process additional claims (JWS §4.1.11)
 function checkHeaderCrit(
   header: Jose,
-  handlers?: Handlers
+  handlers?: Handlers,
 ): Promise<unknown[]> {
   // prettier-ignore
-  const reservedWords = new Set(["alg", "jku", "jwk", "kid", "x5u", "x5c", "x5t",
-    "x5t#S256", "typ", "cty", "crit", "enc", "zip", "epk", "apu", "apv", "iv", "tag", "p2s", "p2c"]);
+  const reservedWords = new Set(
+    [
+      "alg",
+      "jku",
+      "jwk",
+      "kid",
+      "x5u",
+      "x5c",
+      "x5t",
+      "x5t#S256",
+      "typ",
+      "cty",
+      "crit",
+      "enc",
+      "zip",
+      "epk",
+      "apu",
+      "apv",
+      "iv",
+      "tag",
+      "p2s",
+      "p2c",
+    ],
+  );
   if (
     !Array.isArray(header.crit) ||
     header.crit.some((str: string) => typeof str !== "string" || !str)
   ) {
     throw Error(
-      "header parameter 'crit' must be an array of non-empty strings"
+      "header parameter 'crit' must be an array of non-empty strings",
     );
   }
   if (header.crit.some((str: string) => reservedWords.has(str))) {
@@ -68,18 +90,18 @@ function checkHeaderCrit(
     header.crit.some(
       (str: string) =>
         typeof header[str] === "undefined" ||
-        typeof handlers?.[str] !== "function"
+        typeof handlers?.[str] !== "function",
     )
   ) {
     throw Error("critical extension header parameters are not understood");
   }
   return Promise.all(
-    header.crit.map((str: string) => handlers![str](header[str] as JsonValue))
+    header.crit.map((str: string) => handlers![str](header[str] as JsonValue)),
   );
 }
 
 function validateJwtObject(
-  maybeJwtObject: Record<keyof JwtObject, unknown>
+  maybeJwtObject: Record<keyof JwtObject, unknown>,
 ): JwtObject {
   if (typeof maybeJwtObject.signature !== "string") {
     throw ReferenceError("the signature is no string");
@@ -106,7 +128,7 @@ function validateJwtObject(
 
 async function handleJwtObject(
   jwtObject: JwtObject,
-  critHandlers?: Handlers
+  critHandlers?: Handlers,
 ): Promise<[JwtObject, unknown[] | undefined]> {
   return [
     jwtObject,
@@ -146,19 +168,21 @@ async function validateJwt({
   try {
     const [oldJwtObject, critResult] = await handleJwtObject(
       validateJwtObject(parseAndDecode(jwt)),
-      critHandlers
+      critHandlers,
     );
     if (
       !makeArray<Algorithm | Algorithm[]>(algorithm).includes(
-        oldJwtObject.header.alg
+        oldJwtObject.header.alg,
       )
-    )
+    ) {
       throw Error("no matching algorithm: " + oldJwtObject.header.alg);
+    }
     if (
       oldJwtObject.signature !==
-      parseAndDecode(await makeJwt({ ...oldJwtObject, key })).signature
-    )
+        parseAndDecode(await makeJwt({ ...oldJwtObject, key })).signature
+    ) {
       throw Error("signatures don't match");
+    }
     return { ...oldJwtObject, jwt, critResult, isValid: true };
   } catch (err) {
     return {


### PR DESCRIPTION
Refactor some code for easier dependency handling (following Deno standards)
Added warning in README to discourage unversioned imports

### Notes
- Dependencies upgraded to Deno v1.2.2 in a later commit (I recommend you to add a release tag so people can tag along to this version instead of using master https://github.com/denoland/deno/issues/6755)
- I ran `deno fmt` on top of it, so there is a lot of trailing commas added