### PR TITLE
Import types in validate.js

### DIFF
--- a/create.ts
+++ b/create.ts
@@ -93,7 +93,7 @@ export {
   setExpiration,
   makeSignature,
   convertHexToBase64url,
-  convertStringToBase64url,  
+  convertStringToBase64url,
 };
 
 export type {
@@ -103,4 +103,4 @@ export type {
   Jose,
   JwtInput,
   JsonValue,
-}
+};

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,7 @@
-export { decodeString as convertHexToUint8Array, encodeToString as convertUint8ArrayToHex } from "https://deno.land/std@0.69.0/encoding/hex.ts";
+export {
+  decodeString as convertHexToUint8Array,
+  encodeToString as convertUint8ArrayToHex,
+} from "https://deno.land/std@0.69.0/encoding/hex.ts";
 export { HmacSha256 } from "https://deno.land/std@0.69.0/hash/sha256.ts";
 export { HmacSha512 } from "https://deno.land/std@0.69.0/hash/sha512.ts";
 export { addPaddingToBase64url } from "https://deno.land/std@0.69.0/encoding/base64url.ts";

--- a/validate.ts
+++ b/validate.ts
@@ -1,4 +1,5 @@
-import { makeJwt, Payload, Jose, JsonValue, Algorithm } from "./create.ts";
+import { makeJwt } from "./create.ts";
+import type { Jose, Payload, JsonValue, Algorithm } from "./create.ts";
 import { convertBase64urlToUint8Array } from "./base64/base64url.ts";
 import { encodeToString as convertUint8ArrayToHex } from "https://deno.land/std@0.63.0/encoding/hex.ts";
 
@@ -218,4 +219,4 @@ export type {
   JwtObject,
   JwtValidation,
   Validation,
-}
+};


### PR DESCRIPTION
In validate.js types were still imported as normal modules. I also ran `deno fmt`.