### PR TITLE
Bump god_crypto version for PKCS8 key support

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -5,4 +5,4 @@ export {
 } from "https://deno.land/std@0.75.0/encoding/hex.ts";
 export { HmacSha256 } from "https://deno.land/std@0.75.0/hash/sha256.ts";
 export { HmacSha512 } from "https://deno.land/std@0.75.0/hash/sha512.ts";
-export { RSA } from "https://deno.land/x/god_crypto@v1.4.3/rsa.ts";
+export { RSA } from "https://deno.land/x/god_crypto@v1.4.4/rsa.ts";


### PR DESCRIPTION
Upstream issue: https://github.com/invisal/god_crypto/issues/16

I'm using this library to sign JWTs for Google Cloud Service Accounts, and the god_crypto release adds support for reading the RSA private key format which Google Cloud gives you when you create a Service Account.

There's still a minor issue in upstream where the Google private key needs a trailing newline trimmed, and a future release will fix that.