### PR TITLE
Update god_crypto on version 1.7

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -4,5 +4,5 @@ export {
 } from "https://deno.land/std@0.69.0/encoding/hex.ts";
 export { HmacSha256 } from "https://deno.land/std@0.69.0/hash/sha256.ts";
 export { HmacSha512 } from "https://deno.land/std@0.69.0/hash/sha512.ts";
-export { RSA } from "https://cdn.jsdelivr.net/gh/invisal/god_crypto@22eb70429c998d84a57e786217c277373fbeca9f/mod.ts";
+export { RSA } from "https://deno.land/x/god_crypto@v1.4.8/mod.ts";
 export { addPaddingToBase64url } from "https://deno.land/std@0.69.0/encoding/base64url.ts";


### PR DESCRIPTION
Hi there,

Thanks for your work on djwt, it's the go-to solution for using jwt in Deno, and it's been evolving great. It happens that there are libraries using djwt (like https://github.com/halvardssm/oak-middleware-jwt) that are still heavily coupled to the old API, before 1.8 (validateJwt and so on) and will take a while to update. 

They work just fine with the latest versions of Deno, except that they're having problems with the "abstract async" methods on god_crypto (fixed on this PR) https://github.com/invisal/god_crypto/releases/tag/v1.4.6.

It happens that version 1.7 of djwt (which is the one with the old API) is still locked to a version of god_crypto where this breaks.

Sending this PR so that people using version 1.7 can update (for instance into 1.7.1) and get everything to work just fine with the old API and the new versions of deno. This shouldn't be merged on master but on the 1.7 release branch.

Do you think that's feasible? Let me know if I can help.

Thanks