### PR TITLE
Add function validate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: actions/checkout@master
       - uses: denolib/setup-deno@master
         with:
-          deno-version: v1.7.0
+          deno-version: x
       - run: deno test -A

--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ const payload = await verify(jwt, "secret", "HS512") // { foo: "bar" }
 
 ### decode
 
-Takes a `jwt` and returns an object with the `header`, `payload` and `signature`
-properties if the `jwt` is valid (without signature verification). Otherwise it
-throws an `Error`.
+Takes a `jwt` and returns a 3-tuple `[header, payload, signature]` if the `jwt`
+has a valid _serialization_. Otherwise it throws an `Error`.
 
 ```typescript
 import { decode } from "https://deno.land/x/djwt@$VERSION/mod.ts"
@@ -38,8 +37,12 @@ import { decode } from "https://deno.land/x/djwt@$VERSION/mod.ts"
 const jwt =
   "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.WePl7achkd0oGNB8XRF_LJwxlyiPZqpdNgdKpDboAjSTsWq-aOGNynTp8TOv8KjonFym8vwFwppXOLoLXbkIaQ"
 
-const { payload, signature, header } = decode(jwt)
-// { header: { alg: "HS512", typ: "JWT" }, payload: { foo: "bar" }, signature: "59e3e5eda72191dd2818d07c5d117f2c9c3197288f66aa5d36074aa436e8023493b16abe68e18dca74e9f133aff0a8e89c5ca6f2fc05c29a5738ba0b5db90869" }
+const [payload, signature, header] = decode(jwt)
+// [
+// { alg: "HS512", typ: "JWT" },
+// { foo: "bar" },
+// "59e3e5eda72191dd2818d07c5d117f2c9c3197288f66aa5d36074aa436e8023493b16abe68e18dca74e9f133aff0a8e89c5c..."
+// ]
 ```
 
 ### getNumericDate

--- a/deps.ts
+++ b/deps.ts
@@ -5,4 +5,4 @@ export {
 } from "https://deno.land/std@0.85.0/encoding/hex.ts";
 export { HmacSha256 } from "https://deno.land/std@0.85.0/hash/sha256.ts";
 export { HmacSha512 } from "https://deno.land/std@0.85.0/hash/sha512.ts";
-export { RSA } from "https://deno.land/x/god_crypto@v1.4.8/rsa.ts";
+export { RSA } from "https://deno.land/x/god_crypto@v1.4.9/rsa.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,8 +1,8 @@
-export * as base64url from "https://deno.land/std@0.84.0/encoding/base64url.ts";
+export * as base64url from "https://deno.land/std@0.85.0/encoding/base64url.ts";
 export {
   decodeString as convertHexToUint8Array,
   encodeToString as convertUint8ArrayToHex,
-} from "https://deno.land/std@0.84.0/encoding/hex.ts";
-export { HmacSha256 } from "https://deno.land/std@0.84.0/hash/sha256.ts";
-export { HmacSha512 } from "https://deno.land/std@0.84.0/hash/sha512.ts";
+} from "https://deno.land/std@0.85.0/encoding/hex.ts";
+export { HmacSha256 } from "https://deno.land/std@0.85.0/hash/sha256.ts";
+export { HmacSha512 } from "https://deno.land/std@0.85.0/hash/sha512.ts";
 export { RSA } from "https://deno.land/x/god_crypto@v1.4.8/rsa.ts";

--- a/examples/example_deps.ts
+++ b/examples/example_deps.ts
@@ -1,3 +1,3 @@
-export { serve } from "https://deno.land/std@0.84.0/http/server.ts";
-export { decode, encode } from "https://deno.land/std@0.84.0/encoding/utf8.ts";
-export { dirname, fromFileUrl } from "https://deno.land/std@0.84.0/path/mod.ts";
+export { serve } from "https://deno.land/std@0.85.0/http/server.ts";
+export { decode, encode } from "https://deno.land/std@0.85.0/encoding/utf8.ts";
+export { dirname, fromFileUrl } from "https://deno.land/std@0.85.0/path/mod.ts";

--- a/tests/signature_test.ts
+++ b/tests/signature_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "./test_deps.ts";
-import { create, decode } from "../mod.ts";
+import { create, decode, validate } from "../mod.ts";
 
 import {
   convertHexToBase64url,
@@ -33,7 +33,7 @@ Deno.test("[jwt] create signature", async function () {
 
 Deno.test("[jwt] verify signature", async function () {
   const jwt = await create({ alg: "HS512", typ: "JWT" }, {}, key);
-  const { header, signature } = decode(jwt);
+  const { header, signature } = validate(decode(jwt));
   const validSignature = await verifySignature({
     signature,
     key,

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -2,6 +2,6 @@ export {
   assertEquals,
   assertThrows,
   assertThrowsAsync,
-} from "https://deno.land/std@0.84.0/testing/asserts.ts";
+} from "https://deno.land/std@0.85.0/testing/asserts.ts";
 
-export { dirname, fromFileUrl } from "https://deno.land/std@0.84.0/path/mod.ts";
+export { dirname, fromFileUrl } from "https://deno.land/std@0.85.0/path/mod.ts";


### PR DESCRIPTION
This PR divides the function `decode` into the two functions `decode` and `validate`.

The intention is primarily better error handling. For example the error messages thrown by `base64url.decode` were not renamed previously. 

But it also fits better semantically in my opinion.

The downside would be that the `decode` function was exported previously and people had to adapt accordingly. 

I would love to get some feedback.

Thanks!