### PR TITLE
Revert to v2.4 except the addition of 'VerifyOptions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,13 @@ Takes `jwt`, `CryptoKey` and `VerifyOptions` and returns the `Payload` of the
 import { verify } from "https://deno.land/x/djwt@$VERSION/mod.ts";
 
 const payload = await verify(jwt, key); // { foo: "bar" }
-// Accepts an optional type argument:
-const payload = await verify<{ foo: string }>(jwt, key); // { foo: "bar" }
 ```
 
 ### decode
 
 Takes a `jwt` and returns a 3-tuple
-`[header: JsonValue, payload: JsonValue, signature: Uint8Array]` if the `jwt`
-has a valid _serialization_. Otherwise it throws an `Error`. This function does
+`[header: unknown, payload: unknown, signature: Uint8Array]` if the `jwt` has a
+valid _serialization_. Otherwise it throws an `Error`. This function does
 **not** verify the digital signature.
 
 ```typescript
@@ -113,6 +111,15 @@ This application uses the JWS Compact Serialization only.
 - [JSON Web Token](https://tools.ietf.org/html/rfc7519)
 - [JSON Web Signature](https://www.rfc-editor.org/rfc/rfc7515.html)
 - [JSON Web Algorithms](https://www.rfc-editor.org/rfc/rfc7518.html)
+
+## Applications
+
+The following projects use djwt:
+
+- [AuthCompanion](https://github.com/authcompanion/authcompanion): An
+  effortless, token-based user management server - well suited for modern web
+  projects.
+- [Oak Middleware JWT](https://github.com/halvardssm/oak-middleware-jwt)
 
 ## Contribution
 

--- a/algorithm.ts
+++ b/algorithm.ts
@@ -17,12 +17,11 @@ export type Algorithm =
   | "ES384"
   // P-521 is not yet supported.
   // https://github.com/denoland/deno/blob/main/ext/crypto/00_crypto.js
-  // | "ES512"
   | "none";
 
+// Still needs an 'any' type! Does anyone have an idea?
+// https://github.com/denoland/deno/blob/main/ext/crypto/lib.deno_crypto.d.ts
 function isHashedKeyAlgorithm(
-  // Still needs an 'any' type! Does anyone have an idea?
-  // https://github.com/denoland/deno/blob/main/ext/crypto/lib.deno_crypto.d.ts
   // deno-lint-ignore no-explicit-any
   algorithm: Record<string, any>,
 ): algorithm is HmacKeyAlgorithm | RsaHashedKeyAlgorithm {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -141,10 +141,6 @@ const keyES384 = await window.crypto.subtle.generateKey(
 // ["sign", "verify"],
 // );
 
-function acceptString(s: string) {
-  return s;
-}
-
 Deno.test({
   name: "[jwt] create",
   fn: async function () {
@@ -209,14 +205,12 @@ Deno.test({
     );
 
     await assertEquals(
-      acceptString(
-        (await verify<{ name: string }>(
-          await create({ alg: "HS512", typ: "JWT" }, payload, keyHS512),
-          keyHS512,
-          { expLeeway: 10 },
-        )).name,
+      await verify(
+        await create({ alg: "HS512", typ: "JWT" }, {}, keyHS512),
+        keyHS512,
+        { nbfLeeway: 10 },
       ),
-      payload.name,
+      {},
     );
 
     await assertRejects(
@@ -435,8 +429,7 @@ Deno.test({
     );
     assertThrows(
       () => {
-        // deno-lint-ignore no-explicit-any
-        validate([undefined as any, undefined as any, new Uint8Array()]);
+        validate([, , new Uint8Array()]);
       },
       Error,
       "The jwt's 'alg' header parameter value must be a string.",


### PR DESCRIPTION
Reason: The types of `Payload` and `Header` are incorrect in the releases `v2.5` and `v2.6`.