### PR TITLE
Improve option `audience`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ must not be accepted for processing. Its value must be a number containing a
 ### Audience (aud)
 
 The optional `aud` (_audience_) claim identifies the recipients that the JWT is
-intended for. By passing the the option `audience` with the type
-`string | string[]` to `verify`, this application tries to identify the
-recipient with a value in the `aud` claim when this claim is present. If the
-values don't match, an `Error` is thrown.
+intended for. By passing the option `audience` with the type
+`string | string[] | RegExp` to `verify`, this application tries to identify the
+recipient with a value in the `aud` claim. If the values don't match, an `Error`
+is thrown.
 
 ## Algorithms
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -608,14 +608,6 @@ Deno.test({
     );
     assertEquals(
       await verify(
-        await create(header, { ...payload }, keyHS256),
-        keyHS256,
-        { audience: audValue },
-      ),
-      { ...payload },
-    );
-    assertEquals(
-      await verify(
         await create(header, { ...payload, aud: [audValue, "sol"] }, keyHS256),
         keyHS256,
         { audience: audValue },
@@ -645,6 +637,33 @@ Deno.test({
         { audience: [audValue, "sol"] },
       ),
       { ...payload, aud: audValue },
+    );
+    assertEquals(
+      await verify(
+        await create(header, { ...payload, aud: [audValue, "sol"] }, keyHS256),
+        keyHS256,
+        { audience: new RegExp("^s.*") },
+      ),
+      { ...payload, aud: [audValue, "sol"] },
+    );
+    assertEquals(
+      await verify(
+        await create(header, { ...payload, aud: audValue }, keyHS256),
+        keyHS256,
+        { audience: new RegExp("^s.*") },
+      ),
+      { ...payload, aud: audValue },
+    );
+    await assertRejects(
+      async () => {
+        await verify(
+          await create(header, { ...payload }, keyHS256),
+          keyHS256,
+          { audience: audValue },
+        );
+      },
+      Error,
+      "The jwt has no 'aud' claim.",
     );
     await assertRejects(
       async () => {
@@ -681,8 +700,34 @@ Deno.test({
         await verify(
           await create(header, { ...payload, aud: audValue }, keyHS256),
           keyHS256,
+          { audience: new RegExp("^a.*") },
+        );
+      },
+      Error,
+      "The identification with the value in the 'aud' claim has failed.",
+    );
+    await assertRejects(
+      async () => {
+        await verify(
+          await create(
+            header,
+            { ...payload, aud: [audValue, "sol"] },
+            keyHS256,
+          ),
+          keyHS256,
+          { audience: new RegExp("^a.*") },
+        );
+      },
+      Error,
+      "The identification with the value in the 'aud' claim has failed.",
+    );
+    await assertRejects(
+      async () => {
+        await verify(
+          await create(header, { ...payload, aud: audValue }, keyHS256),
+          keyHS256,
           { audience: audValue + "a" },
-        ), { ...payload, aud: audValue };
+        );
       },
       Error,
       "The identification with the value in the 'aud' claim has failed.",


### PR DESCRIPTION
- Add `RegExp` to the union type of 'audience' 
- Throw if the option `audience` is passed but no 'aud' claim is present